### PR TITLE
Add EXE build support and frozen-runtime path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,27 @@ python voice_control.py
 python control.py
 ```
 
+### Windows向けEXEを作成して実行
+
+1. 依存関係をインストールします。
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. EXEをビルドします。
+
+   ```bash
+   python build_exe.py
+   ```
+
+3. `dist/` 配下に `voice-control-gui` と `voice-control-cui` が作成されます。
+   - GUI: `dist/voice-control-gui/voice-control-gui.exe`
+   - CUI: `dist/voice-control-cui/voice-control-cui.exe`
+
+4. 初回設定は `edit_config.py` で作成した `config` フォルダを、EXEと同じ階層に配置してください。
+
+
 ### 音声コマンド例
 
 以下は、音声コマンドの例です。このコマンド以外にもさまざまなコマンドが使えます。

--- a/app_paths.py
+++ b/app_paths.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+
+def get_app_dir() -> str:
+    """設定ファイルなどの書き込み先ディレクトリを返す。"""
+    if getattr(sys, "frozen", False):
+        return os.path.dirname(sys.executable)
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def get_resource_dir() -> str:
+    """同梱リソースの参照先ディレクトリを返す。"""
+    if hasattr(sys, "_MEIPASS"):
+        return sys._MEIPASS
+    return get_app_dir()
+
+
+def ensure_config_dir() -> str:
+    config_dir = os.path.join(get_app_dir(), "config")
+    os.makedirs(config_dir, exist_ok=True)
+    return config_dir

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,34 @@
+import pkgutil
+import subprocess
+import sys
+
+import plugins
+
+
+def build(entry_script: str, name: str):
+    hidden_imports = []
+    for module_info in pkgutil.iter_modules(plugins.__path__):
+        hidden_imports.extend(["--hidden-import", f"plugins.{module_info.name}"])
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        "--clean",
+        "--onedir",
+        "--name",
+        name,
+        *hidden_imports,
+        entry_script,
+    ]
+    print(" ".join(cmd))
+    subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    # GUI版
+    build("control.py", "voice-control-gui")
+    # CUI版
+    build("voice_control.py", "voice-control-cui")
+    print("Build completed. dist/ 以下を配布してください。")

--- a/control.py
+++ b/control.py
@@ -4,6 +4,7 @@ import datetime
 import asyncio
 import voice_control
 import os
+from app_paths import get_app_dir
 import threading
 import time
 import pychromecast
@@ -270,7 +271,7 @@ class VoiceControlUI:
         """音声コントロールのセットアップ"""
         try:
             import json
-            dir_name = os.path.dirname(__file__)
+            dir_name = get_app_dir()
 
             config_files = {
                 "custom_scenes": "custom_scenes.json",

--- a/edit_config.py
+++ b/edit_config.py
@@ -1,10 +1,12 @@
 from plugin import PluginManager
 import json
 import os
-dir_name = os.path.dirname(__file__)
+from app_paths import get_app_dir, ensure_config_dir
+dir_name = get_app_dir()
 
 
 def setup():
+    ensure_config_dir()
     custom_devices = {"deviceList": []}
     custom_scenes = {"sceneList": []}
     custom_routines = {"routineList": []}

--- a/plugin.py
+++ b/plugin.py
@@ -4,9 +4,12 @@ import inspect
 import os
 import json
 import asyncio
+import pkgutil
+import plugins
 from commands import VoiceCommand
 import time
-dir_name = os.path.dirname(os.path.abspath(__file__))
+from app_paths import get_app_dir
+dir_name = get_app_dir()
 
 
 class PluginManager:
@@ -16,41 +19,39 @@ class PluginManager:
         self.voice_control = voice_control
 
     def get_plugins(self):
-        plugins = []
-        for filename in os.listdir(os.path.join(dir_name, self.plugin_dir)):
+        loaded_plugins = []
+        for module_info in pkgutil.iter_modules(plugins.__path__):
             try:
-                if filename.endswith(".py") and filename != "__init__.py":
-                    module_name = f"plugins.{filename[:-3]}"
-                    module = importlib.import_module(module_name)
-                    for name, obj in inspect.getmembers(module, inspect.isclass):
-                        if issubclass(obj, BasePlugin) and obj != BasePlugin:
-                            plugins.append(obj())
+                module_name = f"plugins.{module_info.name}"
+                module = importlib.import_module(module_name)
+                for name, obj in inspect.getmembers(module, inspect.isclass):
+                    if issubclass(obj, BasePlugin) and obj != BasePlugin:
+                        loaded_plugins.append(obj())
             except OSError as e:
                 print(f"プラグインファイルの読み込み中にエラーが発生しました: {e}")
             except Exception as e:
                 print(f"プラグインの読み込みにエラーが発生しました: {e}")
-        return plugins
+        return loaded_plugins
 
     def load_plugins(self):
-        plugins = []
+        loaded_plugins = []
         enabled_plugins = json.load(
             open(os.path.join(dir_name, "config/config.json"))).get("plugins", {})
-        for filename in os.listdir(os.path.join(dir_name, self.plugin_dir)):
+        for module_info in pkgutil.iter_modules(plugins.__path__):
             try:
-                if filename.endswith(".py") and filename != "__init__.py":
-                    module_name = f"plugins.{filename[:-3]}"
-                    module = importlib.import_module(module_name)
-                    for name, cls in inspect.getmembers(module, inspect.isclass):
-                        if issubclass(cls, BasePlugin) and cls != BasePlugin:
-                            obj = cls(self.voice_control)
-                            if obj.name in enabled_plugins:
-                                plugins.append(obj)
+                module_name = f"plugins.{module_info.name}"
+                module = importlib.import_module(module_name)
+                for name, cls in inspect.getmembers(module, inspect.isclass):
+                    if issubclass(cls, BasePlugin) and cls != BasePlugin:
+                        obj = cls(self.voice_control)
+                        if obj.name in enabled_plugins:
+                            loaded_plugins.append(obj)
             except OSError as e:
                 print(f"プラグインファイルの読み込み中にエラーが発生しました: {e}")
             except Exception as e:
                 print(f"プラグインの読み込みにエラーが発生しました: {e}")
-        self.plugins = plugins
-        return plugins
+        self.plugins = loaded_plugins
+        return loaded_plugins
 
 
 class Notification:

--- a/plugins/switchbot.py
+++ b/plugins/switchbot.py
@@ -10,8 +10,8 @@ import requests
 import os
 import datetime
 import re
-dir_name = os.path.dirname(__file__)
-dir_name = os.path.abspath(os.path.join(dir_name, os.pardir))
+from app_paths import get_app_dir
+dir_name = get_app_dir()
 
 
 class Switchbot:

--- a/plugins/watchlist.py
+++ b/plugins/watchlist.py
@@ -3,6 +3,7 @@ import flet as ft
 import requests
 import pickle
 from bs4 import BeautifulSoup
+from app_paths import ensure_config_dir
 
 
 class WatchList:
@@ -14,14 +15,14 @@ class WatchList:
 
     def load_cookies(self):
         try:
-            with open("config/watchlist_cookies.pkl", "rb") as f:
+            with open(f"{ensure_config_dir()}/watchlist_cookies.pkl", "rb") as f:
                 cookies = pickle.load(f)
         except FileNotFoundError:
             cookies = {}
         return cookies
 
     def save_cookies(self, cookies):
-        with open("config/watchlist_cookies.pkl", "wb") as f:
+        with open(f"{ensure_config_dir()}/watchlist_cookies.pkl", "wb") as f:
             pickle.dump(cookies, f)
 
     def account_login(self, username, password):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
 faster-whisper
+pyinstaller

--- a/voice_control.py
+++ b/voice_control.py
@@ -17,7 +17,8 @@ import fastmcp
 from faster_whisper import WhisperModel
 from plugin import PluginManager
 from commands import VoiceCommand
-dir_name = os.path.dirname(__file__)
+from app_paths import get_app_dir
+dir_name = get_app_dir()
 
 
 class VoiceRecognizer:


### PR DESCRIPTION
### Motivation
- Make it possible to build and distribute Windows executables and ensure config/plugins/cookie files are resolved correctly when the application runs as a frozen `.exe`.
- Avoid plugin discovery and file-path issues that commonly occur after packaging with PyInstaller by centralizing runtime path resolution.

### Description
- Added `app_paths.py` which provides `get_app_dir()`, `get_resource_dir()` and `ensure_config_dir()` to resolve write/read paths consistently for normal and frozen execution.
- Added `build_exe.py` to build GUI (`control.py`) and CUI (`voice_control.py`) distributions using PyInstaller and to collect plugin modules as hidden imports via `pkgutil`.
- Updated core modules to use `get_app_dir()`/`ensure_config_dir()` so `voice_control.py`, `control.py` and `edit_config.py` load and write `config/` next to the executable at runtime.
- Switched plugin discovery/loading to `pkgutil.iter_modules()` in `plugin.py` and adjusted plugins (`plugins/switchbot.py`, `plugins/watchlist.py`) to use `app_paths` for config/cookie file paths.
- Documented the EXE build/run steps in `README.md` and added `pyinstaller` to `requirements.txt`.

### Testing
- Compiled key files with `python -m py_compile app_paths.py build_exe.py voice_control.py control.py plugin.py edit_config.py plugins/watchlist.py plugins/switchbot.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1573327c0832786a672e2bf40139e)